### PR TITLE
Fix phone regex in client validation

### DIFF
--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -15,7 +15,7 @@ export function validateCustomer(customer: Partial<Customer>): FormErrors {
 
   if (!customer.phone?.trim()) {
     errors.phone = "Phone is required"
-  } else if (!/^\+?[\d\s\-$$$$]+$/.test(customer.phone)) {
+  } else if (!/^\+?[\d\s\-()]+$/.test(customer.phone)) {
     errors.phone = "Invalid phone format"
   }
 


### PR DESCRIPTION
## Summary
- correct phone validation regex

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5c57c13483339a6ab947452530c2