### PR TITLE
Implement global search

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -12,7 +12,7 @@ interface LayoutProps {
 }
 
 export function Layout({ children }: LayoutProps) {
-  const { currentPage, setCurrentPage, toasts, removeToast } = useApp()
+  const { currentPage, setCurrentPage, toasts, removeToast, searchTerm, setSearchTerm } = useApp()
 
   const navigationItems = [
     { id: "dashboard", label: "Dashboard", icon: BarChart3 },
@@ -79,7 +79,12 @@ export function Layout({ children }: LayoutProps) {
           <h1 className="text-2xl font-medium text-[#1c1a21]">{getPageTitle()}</h1>
           <div className="relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-[#9197b3] w-5 h-5" />
-            <Input placeholder="Search" className="pl-10 w-80 bg-white border-[#cecece]" />
+            <Input
+              placeholder="Search"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-10 w-80 bg-white border-[#cecece]"
+            />
           </div>
         </div>
 

--- a/components/SearchAndFilter.tsx
+++ b/components/SearchAndFilter.tsx
@@ -10,6 +10,7 @@ interface SearchAndFilterProps {
   onStatusFilter: (status: string) => void
   placeholder?: string
   showStatusFilter?: boolean
+  showSearch?: boolean
   className?: string
 }
 
@@ -18,6 +19,7 @@ export function SearchAndFilter({
   onStatusFilter,
   placeholder = "Search...",
   showStatusFilter = true,
+  showSearch = true,
   className = "",
 }: SearchAndFilterProps) {
   const [searchTerm, setSearchTerm] = useState("")
@@ -35,15 +37,17 @@ export function SearchAndFilter({
 
   return (
     <div className={`flex items-center gap-4 ${className}`}>
-      <div className="relative flex-1 max-w-md">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-[#9197b3] w-4 h-4" />
-        <Input
-          placeholder={placeholder}
-          value={searchTerm}
-          onChange={(e) => handleSearchChange(e.target.value)}
-          className="pl-10 bg-white border-[#cecece]"
-        />
-      </div>
+      {showSearch && (
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-[#9197b3] w-4 h-4" />
+          <Input
+            placeholder={placeholder}
+            value={searchTerm}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="pl-10 bg-white border-[#cecece]"
+          />
+        </div>
+      )}
 
       {showStatusFilter && (
         <div className="flex items-center gap-2">

--- a/components/pages/CustomersPage.tsx
+++ b/components/pages/CustomersPage.tsx
@@ -4,6 +4,7 @@ import { Users, UserCheck, UserX, Plus } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { useState } from "react"
+import { useApp } from "../../context/AppContext"
 import { useCustomers } from "../../hooks/useApi"
 import { MetricCard } from "../shared/MetricCard"
 import { DataTable } from "../shared/DataTable"
@@ -17,7 +18,7 @@ import { ToastContainer } from "../Toast"
 
 export function CustomersPage() {
   const [page, setPage] = useState(1)
-  const [search, setSearch] = useState("")
+  const { searchTerm, setSearchTerm } = useApp()
   const [status, setStatus] = useState("")
   const [customerFormOpen, setCustomerFormOpen] = useState(false)
   const [editingCustomer, setEditingCustomer] = useState<any>(undefined)
@@ -43,7 +44,7 @@ export function CustomersPage() {
     createCustomer,
     updateCustomer,
     deleteCustomer,
-  } = useCustomers({ page, limit: 10, search, status })
+  } = useCustomers({ page, limit: 10, search: searchTerm, status })
 
   const activeCustomers = customers.filter((c: any) => c.status === "Active").length
   const inactiveCustomers = customers.filter((c: any) => c.status === "Inactive").length
@@ -150,10 +151,11 @@ export function CustomersPage() {
         <CardContent>
           {/* Search and Filter */}
           <SearchAndFilter
-            onSearch={setSearch}
+            onSearch={setSearchTerm}
             onStatusFilter={setStatus}
             placeholder="Search customers..."
             className="mb-6"
+            showSearch={false}
           />
 
           {/* Loading State */}

--- a/components/pages/DashboardPage.tsx
+++ b/components/pages/DashboardPage.tsx
@@ -14,7 +14,7 @@ import { ConfirmDialog } from "../ConfirmDialog"
 import type { Customer } from "../../types"
 
 export function DashboardPage() {
-  const { customers, updateCustomer, deleteCustomer, addCustomer } = useApp()
+  const { customers, updateCustomer, deleteCustomer, addCustomer, searchTerm } = useApp()
   const [customerFormOpen, setCustomerFormOpen] = useState(false)
   const [editingCustomer, setEditingCustomer] = useState<Customer | undefined>()
   const [confirmDialog, setConfirmDialog] = useState<{
@@ -30,6 +30,9 @@ export function DashboardPage() {
   })
 
   const activeCustomers = customers.filter((c) => c.status === "Active").length
+  const filteredCustomers = customers.filter((c) =>
+    c.name.toLowerCase().includes(searchTerm.toLowerCase())
+  )
 
   const handleEditCustomer = (customer: Customer) => {
     setEditingCustomer(customer)
@@ -94,7 +97,7 @@ export function DashboardPage() {
           </div>
 
           <DataTable
-            data={customers}
+            data={filteredCustomers}
             columns={customerColumns}
             onEdit={handleEditCustomer}
             onDelete={handleDeleteCustomer}

--- a/components/pages/ProductsPage.tsx
+++ b/components/pages/ProductsPage.tsx
@@ -4,6 +4,7 @@ import { Package, BarChart3, Plus } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { useState } from "react"
+import { useApp } from "../../context/AppContext"
 import { useProducts } from "../../hooks/useApi"
 import { MetricCard } from "../shared/MetricCard"
 import { DataTable } from "../shared/DataTable"
@@ -17,7 +18,7 @@ import { ToastContainer } from "../Toast"
 
 export function ProductsPage() {
   const [page, setPage] = useState(1)
-  const [search, setSearch] = useState("")
+  const { searchTerm, setSearchTerm } = useApp()
   const [status, setStatus] = useState("")
   const [productFormOpen, setProductFormOpen] = useState(false)
   const [editingProduct, setEditingProduct] = useState<any>(undefined)
@@ -43,9 +44,12 @@ export function ProductsPage() {
     createProduct,
     updateProduct,
     deleteProduct,
-  } = useProducts({ page, limit: 10, search, status })
+  } = useProducts({ page, limit: 10, search: searchTerm, status })
 
   const totalInventory = products.reduce((sum: number, p: any) => sum + p.inventory, 0)
+  const filteredProducts = products.filter((p: any) =>
+    p.name.toLowerCase().includes(searchTerm.toLowerCase())
+  )
 
   const handleEditProduct = (product: any) => {
     setEditingProduct(product)
@@ -141,10 +145,11 @@ export function ProductsPage() {
         <CardContent>
           {/* Search and Filter */}
           <SearchAndFilter
-            onSearch={setSearch}
+            onSearch={setSearchTerm}
             onStatusFilter={setStatus}
             placeholder="Search products..."
             className="mb-6"
+            showSearch={false}
           />
 
           {/* Loading State */}
@@ -156,7 +161,7 @@ export function ProductsPage() {
             <>
               {/* Data Table */}
               <DataTable
-                data={products}
+                data={filteredProducts}
                 columns={productColumns}
                 onEdit={handleEditProduct}
                 onDelete={handleDeleteProduct}

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -96,6 +96,10 @@ interface AppContextType {
   addToast: (message: string, type?: "success" | "error" | "info") => void
   toasts: any[]
   removeToast: (id: string) => void
+
+  // Global search term
+  searchTerm: string
+  setSearchTerm: (term: string) => void
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
@@ -104,6 +108,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [currentPage, setCurrentPage] = useState("dashboard")
   const [customers, setCustomers] = useLocalStorage<Customer[]>("customers", initialCustomers)
   const [products, setProducts] = useLocalStorage<Product[]>("products", initialProducts)
+  const [searchTerm, setSearchTerm] = useState("")
   const { toasts, addToast, removeToast } = useToast()
 
   // Customer operations
@@ -168,6 +173,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     addToast,
     toasts,
     removeToast,
+    searchTerm,
+    setSearchTerm,
   }
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>


### PR DESCRIPTION
## Summary
- wire search input in layout to a new global `searchTerm`
- hide page-specific search boxes
- query API hooks using the global search term
- filter dashboard tables using global search

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e5d8960748333a53dda5baad9c3df