### PR TITLE
Fix mockDB issue with API routes

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,4 +1,3 @@
-"use client"
 
 // Enhanced Mock MongoDB implementation with better error handling
 export interface MongoDocument {


### PR DESCRIPTION
## Summary
- remove `use client` directive from `lib/mongodb.ts` so server API routes use the mock database correctly

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f93a23f488333bfcceb25af8d670f